### PR TITLE
Fixed infinite loop

### DIFF
--- a/vnstat.php
+++ b/vnstat.php
@@ -24,16 +24,20 @@ function kbytesToString($kb, $wSuf = false, $targetSize = null)
     $units = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
     $diff = 0;
 
-    if ($targetSize === null) {
+    if ($kb != 0) {
 
-        $diff = floor(log($kb) / log(1000));
-        $targetSize = $units[$diff];
+        if ($targetSize === null) {
 
-    } else {
+            $diff = floor(log($kb) / log(1000));
+            $targetSize = $units[$diff];
 
-        $diff = array_search($targetSize, $units);
-        if ($diff === FALSE) {
-            throw new \InvalidArgument('Unknown notation ' . $targetSize);
+        } else {
+
+            $diff = array_search($targetSize, $units);
+            if ($diff === FALSE) {
+                throw new \InvalidArgument('Unknown notation ' . $targetSize);
+            }
+
         }
 
     }

--- a/vnstat.php
+++ b/vnstat.php
@@ -18,27 +18,32 @@
  */
 
 // $wSuf (without suffix MB, GB, etc)
-function kbytesToString($kb, $wSuf = false, $byte_notation = null)
+function kbytesToString($kb, $wSuf = false, $targetSize = null)
 {
-    $units = ['TB', 'GB', 'MB', 'KB'];
-    $scale = 1024 * 1024 * 1024;
-    $ui = 0;
 
-    $custom_size = isset($byte_notation) && in_array($byte_notation, $units);
+    $units = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+    $diff = 0;
 
-    while ((($kb < $scale) && ($scale > 1)) || $custom_size) {
-        $ui++;
-        $scale = $scale / 1024;
+    if ($targetSize === null) {
 
-        if ($custom_size && $units[$ui] == $byte_notation) {
-            break;
+        $diff = floor(log($kb) / log(1000));
+        $targetSize = $units[$diff];
+
+    } else {
+
+        $diff = array_search($targetSize, $units);
+        if ($diff === FALSE) {
+            throw new \InvalidArgument('Unknown notation ' . $targetSize);
         }
+
     }
 
+    $value = $kb / (1000 ** $diff);
+
     if ($wSuf == true) {
-        return sprintf("%0.2f", ($kb / $scale));
+        return sprintf('%0.2f', $value);
     } else {
-        return sprintf("%0.2f %s", ($kb / $scale), $units[$ui]);
+        return sprintf('%0.2f %s', $value, $units[$diff]);
     }
 }
 


### PR DESCRIPTION
This fixes an infinite loop which occurred on my server when calling the kbytesToString method in the following manner:

`var_dump(kbytesToString(84021969, true, 'TB'));`

It also adds support for petabyte and exabyte measurements (Not that anyone will reach it)