### PR TITLE
Bugfix of wrong "prefix"

### DIFF
--- a/index.php
+++ b/index.php
@@ -118,11 +118,7 @@ if (isset($_GET['i'])) {
                         continue;
                     }
 
-                    if ($i == 23) {
-                        echo("['" . $hour . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "]\n");
-                    } else {
-                        echo("['" . $hour . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "],\n");
-                    }
+                    echo("['" . $hour . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "],\n");
                 }
                 ?>
             ]);
@@ -157,11 +153,7 @@ if (isset($_GET['i'])) {
                         continue;
                     }
 
-                    if ($i == 29) {
-                        echo("['" . $day . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "]\n");
-                    } else {
-                        echo("['" . $day . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "],\n");
-                    }
+                    echo("['" . $day . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "],\n");
                 }
                 ?>
             ]);
@@ -192,11 +184,7 @@ if (isset($_GET['i'])) {
                     $outTraffic = bytesToString($monthlyGraph[$i]['tx'], true, $monthlyLargestPrefix);
                     $totalTraffic = bytesToString($monthlyGraph[$i]['total'], true, $monthlyLargestPrefix);
 
-                    if ($i == 23) {
-                        echo("['" . $hour . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "]\n");
-                    } else {
-                        echo("['" . $hour . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "],\n");
-                    }
+                    echo("['" . $hour . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "],\n");
                 }
                 ?>
             ]);

--- a/index.php
+++ b/index.php
@@ -110,9 +110,9 @@ if (isset($_GET['i'])) {
 
                 for ($i = 0; $i < count($hourlyGraph); $i++) {
                     $hour = $hourlyGraph[$i]['label'];
-                    $inTraffic = kbytesToString($hourlyGraph[$i]['rx'], true, $hourlyLargestPrefix);
-                    $outTraffic = kbytesToString($hourlyGraph[$i]['tx'], true, $hourlyLargestPrefix);
-                    $totalTraffic = kbytesToString($hourlyGraph[$i]['total'], true, $hourlyLargestPrefix);
+                    $inTraffic = bytesToString($hourlyGraph[$i]['rx'], true, $hourlyLargestPrefix);
+                    $outTraffic = bytesToString($hourlyGraph[$i]['tx'], true, $hourlyLargestPrefix);
+                    $totalTraffic = bytesToString($hourlyGraph[$i]['total'], true, $hourlyLargestPrefix);
 
                     if (($hourlyGraph[$i]['label'] == "12am") && ($hourlyGraph[$i]['time'] == "0")) {
                         continue;
@@ -149,9 +149,9 @@ if (isset($_GET['i'])) {
 
                 for ($i = 0; $i < count($dailyGraph); $i++) {
                     $day = $dailyGraph[$i]['label'];
-                    $inTraffic = kbytesToString($dailyGraph[$i]['rx'], true, $dailyLargestPrefix);
-                    $outTraffic = kbytesToString($dailyGraph[$i]['tx'], true, $dailyLargestPrefix);
-                    $totalTraffic = kbytesToString($dailyGraph[$i]['total'], true, $dailyLargestPrefix);
+                    $inTraffic = bytesToString($dailyGraph[$i]['rx'], true, $dailyLargestPrefix);
+                    $outTraffic = bytesToString($dailyGraph[$i]['tx'], true, $dailyLargestPrefix);
+                    $totalTraffic = bytesToString($dailyGraph[$i]['total'], true, $dailyLargestPrefix);
 
                     if ($dailyGraph[$i]['time'] == "0") {
                         continue;
@@ -188,9 +188,9 @@ if (isset($_GET['i'])) {
 
                 for ($i = 0; $i < count($monthlyGraph); $i++) {
                     $hour = $monthlyGraph[$i]['label'];
-                    $inTraffic = kbytesToString($monthlyGraph[$i]['rx'], true, $monthlyLargestPrefix);
-                    $outTraffic = kbytesToString($monthlyGraph[$i]['tx'], true, $monthlyLargestPrefix);
-                    $totalTraffic = kbytesToString($monthlyGraph[$i]['total'], true, $monthlyLargestPrefix);
+                    $inTraffic = bytesToString($monthlyGraph[$i]['rx'], true, $monthlyLargestPrefix);
+                    $outTraffic = bytesToString($monthlyGraph[$i]['tx'], true, $monthlyLargestPrefix);
+                    $totalTraffic = bytesToString($monthlyGraph[$i]['total'], true, $monthlyLargestPrefix);
 
                     if ($i == 23) {
                         echo("['" . $hour . "', " . $inTraffic . " , " . $outTraffic . ", " . $totalTraffic . "]\n");

--- a/vnstat.php
+++ b/vnstat.php
@@ -18,15 +18,16 @@
  */
 
 // $wSuf (without suffix MB, GB, etc)
-function kbytesToString($kb, $wSuf = false, $byte_notation = null)
+function bytesToString($bytes, $wSuf = false, $byte_notation = null)
 {
+    //print $byte . (($byte_notation !== null)?(" " . $byte_notation):("")) . " / ";
     $units = ['TB', 'GB', 'MB', 'KB'];
     $scale = 1024 * 1024 * 1024 * 1024;
     $ui = 0;
 
     $custom_size = isset($byte_notation) && in_array($byte_notation, $units);
 
-    while ((($kb < $scale) && ($scale > 1)) || $custom_size) {
+    while ((($bytes < $scale) && ($scale > 1)) || $custom_size) {
 
         if ($custom_size && $units[$ui] == $byte_notation) {
             break;
@@ -36,9 +37,9 @@ function kbytesToString($kb, $wSuf = false, $byte_notation = null)
     }
 
     if ($wSuf == true) {
-        return sprintf("%0.2f", ($kb / $scale));
+        return sprintf("%0.2f", ($bytes / $scale));
     } else {
-        return sprintf("%0.2f %s", ($kb / $scale), $units[$ui]);
+        return sprintf("%0.2f %s", ($bytes / $scale), $units[$ui]);
     }
 }
 
@@ -69,13 +70,13 @@ function getLargestValue($array)
     });
 }
 
-function getLargestPrefix($kb)
+function getLargestPrefix($bytes)
 {
     $units = ['TB', 'GB', 'MB', 'KB'];
-    $scale = 1024 * 1024 * 1024;
+    $scale = 1024 * 1024 * 1024 * 1024;
     $ui = 0;
 
-    while ((($kb < $scale) && ($scale > 1))) {
+    while ((($bytes < $scale) && ($scale > 1))) {
         $ui++;
         $scale = $scale / 1024;
     }
@@ -117,10 +118,10 @@ function getVnstatData($path, $type, $interface)
             ++$i;
 
             $top10[$i]['label'] = date('d/m/Y', strtotime($top['date']['month'] . "/" . $top['date']['day'] . "/" . $top['date']['year']));
-            $top10[$i]['rx'] = kbytesToString($top['rx']);
-            $top10[$i]['tx'] = kbytesToString($top['tx']);
+            $top10[$i]['rx'] = bytesToString($top['rx']);
+            $top10[$i]['tx'] = bytesToString($top['tx']);
             $top10[$i]['totalraw'] = ($top['rx'] + $top['tx']);
-            $top10[$i]['total'] = kbytesToString($top['rx'] + $top['tx']);
+            $top10[$i]['total'] = bytesToString($top['rx'] + $top['tx']);
         }
     }
 
@@ -130,10 +131,10 @@ function getVnstatData($path, $type, $interface)
             ++$i;
 
             $daily[$i]['label'] = date('d/m/Y', mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']));
-            $daily[$i]['rx'] = kbytesToString($day['rx']);
-            $daily[$i]['tx'] = kbytesToString($day['tx']);
+            $daily[$i]['rx'] = bytesToString($day['rx']);
+            $daily[$i]['tx'] = bytesToString($day['tx']);
             $daily[$i]['totalraw'] = ($day['rx'] + $day['tx']);
-            $daily[$i]['total'] = kbytesToString($day['rx'] + $day['tx']);
+            $daily[$i]['total'] = bytesToString($day['rx'] + $day['tx']);
             $daily[$i]['time'] = mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']);
 
             $dailyGraph[$i]['label'] = date('jS', mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']));
@@ -150,10 +151,10 @@ function getVnstatData($path, $type, $interface)
             ++$i;
 
             $hourly[$i]['label'] = date("ga", mktime($hour['id'], 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']));
-            $hourly[$i]['rx'] = kbytesToString($hour['rx']);
-            $hourly[$i]['tx'] = kbytesToString($hour['tx']);
+            $hourly[$i]['rx'] = bytesToString($hour['rx']);
+            $hourly[$i]['tx'] = bytesToString($hour['tx']);
             $hourly[$i]['totalraw'] = ($hour['rx'] + $hour['tx']);
-            $hourly[$i]['total'] = kbytesToString($hour['rx'] + $hour['tx']);
+            $hourly[$i]['total'] = bytesToString($hour['rx'] + $hour['tx']);
             $hourly[$i]['time'] = mktime($hour['id'], 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']);
 
             $hourlyGraph[$i]['label'] = date("ga", mktime($hour['id'], 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']));
@@ -172,10 +173,10 @@ function getVnstatData($path, $type, $interface)
             ++$i;
 
             $monthly[$i]['label'] = date('F', mktime(0, 0, 0, $month['date']['month'], 10));
-            $monthly[$i]['rx'] = kbytesToString($month['rx']);
-            $monthly[$i]['tx'] = kbytesToString($month['tx']);
+            $monthly[$i]['rx'] = bytesToString($month['rx']);
+            $monthly[$i]['tx'] = bytesToString($month['tx']);
             $monthly[$i]['totalraw'] = ($month['rx'] + $month['tx']);
-            $monthly[$i]['total'] = kbytesToString($month['rx'] + $month['tx']);
+            $monthly[$i]['total'] = bytesToString($month['rx'] + $month['tx']);
             $monthly[$i]['time'] = mktime(0, 0, 0, $month['date']['month'], 1, $month['date']['year']);
 
             $monthlyGraph[$i]['label'] = date('F', mktime(0, 0, 0, $month['date']['month'], 10));

--- a/vnstat.php
+++ b/vnstat.php
@@ -21,7 +21,7 @@
 function bytesToString($bytes, $wSuf = false, $byte_notation = null)
 {
     //print $byte . (($byte_notation !== null)?(" " . $byte_notation):("")) . " / ";
-    $units = ['TB', 'GB', 'MB', 'KB'];
+    $units = ['TiB', 'GiB', 'MiB', 'KiB'];
     $scale = 1024 * 1024 * 1024 * 1024;
     $ui = 0;
 
@@ -72,7 +72,7 @@ function getLargestValue($array)
 
 function getLargestPrefix($bytes)
 {
-    $units = ['TB', 'GB', 'MB', 'KB'];
+    $units = ['TiB', 'GiB', 'MiB', 'KiB'];
     $scale = 1024 * 1024 * 1024 * 1024;
     $ui = 0;
 


### PR DESCRIPTION
The function getLargestPrefix has not been updated at 6c9299dc69912863ff9a94ed3d4b9550b4d21b66
thus the prefixes at the graph are wrong. (change in vnstat.php line 75)

I have also changed the variable names to bytes to show that this are byte values and not kilobytes

When talking about Prefixes they should be named KiB / MiB / GiB / TiB as the output values are Kibibytes / ....