### PR TITLE
Add support for 5 minute data from vnstat 2.x

### DIFF
--- a/config.php
+++ b/config.php
@@ -23,6 +23,9 @@ date_default_timezone_set('Europe/London');
 // Path of vnstat
 $vnstat_bin_dir = '/usr/bin/vnstat';
 
+// Uncomment to override default config file
+//$vnstat_config = '/etc/vnstat.conf';
+
 // Set to true to set your own interfaces
 $use_predefined_interfaces = false;
 

--- a/index.php
+++ b/index.php
@@ -77,6 +77,13 @@ if (isset($_GET['i'])) {
     // Assume they mean the first interface
     $thisInterface = reset($interface_list);
 }
+
+if (isset($vnstat_config)) {
+    $vnstat_cmd = $vnstat_bin_dir.' --config '.$vnstat_config;
+} else {
+    $vnstat_cmd = $vnstat_bin_dir;
+}
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -105,7 +112,7 @@ if (isset($_GET['i'])) {
             var data = new google.visualization.arrayToDataTable([
                 [{type: 'datetime', label: 'Time'}, 'Traffic In', 'Traffic Out', 'Total Traffic'],
                 <?php
-                $fiveGraph = getVnstatData($vnstat_bin_dir, "fiveGraph", $thisInterface);
+                $fiveGraph = getVnstatData($vnstat_cmd, "fiveGraph", $thisInterface);
 
                 $fiveLargestValue = getLargestValue($fiveGraph);
                 $fiveSmallestValue = getSmallestValue($fiveGraph);
@@ -142,10 +149,12 @@ if (isset($_GET['i'])) {
                 }
             };
 
-            //var chart = new google.charts.Bar(document.getElementById('fiveNetworkTrafficGraph'));
-            var chart = new google.visualization.BarChart(document.getElementById('fiveNetworkTrafficGraph'));
-            //chart.draw(data, google.charts.Bar.convertOptions(options));
-            chart.draw(data, options);
+            if (data.getNumberOfRows() > 0) {
+                //var chart = new google.charts.Bar(document.getElementById('fiveNetworkTrafficGraph'));
+                var chart = new google.visualization.BarChart(document.getElementById('fiveNetworkTrafficGraph'));
+                //chart.draw(data, google.charts.Bar.convertOptions(options));
+                chart.draw(data, options);
+            }
         }
 
         function drawHourlyChart()
@@ -153,7 +162,7 @@ if (isset($_GET['i'])) {
             let data = google.visualization.arrayToDataTable([
                 ['Hour', 'Traffic In', 'Traffic Out', 'Total Traffic'],
                 <?php
-                $hourlyGraph = getVnstatData($vnstat_bin_dir, "hourlyGraph", $thisInterface);
+                $hourlyGraph = getVnstatData($vnstat_cmd, "hourlyGraph", $thisInterface);
 
                 $hourlyLargestValue = getLargestValue($hourlyGraph);
                 $hourlyLargestPrefix = getLargestPrefix($hourlyLargestValue);
@@ -193,7 +202,7 @@ if (isset($_GET['i'])) {
             let data = google.visualization.arrayToDataTable([
                 ['Day', 'Traffic In', 'Traffic Out', 'Total Traffic'],
                 <?php
-                $dailyGraph = getVnstatData($vnstat_bin_dir, "dailyGraph", $thisInterface);
+                $dailyGraph = getVnstatData($vnstat_cmd, "dailyGraph", $thisInterface);
 
                 $dailyLargestValue = getLargestValue($dailyGraph);
                 $dailyLargestPrefix = getLargestPrefix($dailyLargestValue);
@@ -234,7 +243,7 @@ if (isset($_GET['i'])) {
             let data = google.visualization.arrayToDataTable([
                 ['Month', 'Traffic In', 'Traffic Out', 'Total Traffic'],
                 <?php
-                $monthlyGraph = getVnstatData($vnstat_bin_dir, "monthlyGraph", $thisInterface);
+                $monthlyGraph = getVnstatData($vnstat_cmd, "monthlyGraph", $thisInterface);
 
                 $monthlyLargestValue = getLargestValue($monthlyGraph);
                 $monthlyLargestPrefix = getLargestPrefix($monthlyLargestValue);
@@ -277,18 +286,20 @@ if (isset($_GET['i'])) {
 <div id="graphTabNav" class="container">
     <ul class="nav nav-tabs">
         <li class="active">
-            <a href="#fiveGraph" data-toggle="tab">5Min</a></li>
-        <li><a href="#hourlyGraph" data-toggle="tab">Hourly</a></li>
+        <?php if ($version > 1) { echo "<a href=\"#fiveGraph\" data-toggle=\"tab\">5Min</a></li> <li>"; } ?>
+            <a href="#hourlyGraph" data-toggle="tab">Hourly</a></li>
         <li><a href="#dailyGraph" data-toggle="tab">Daily</a></li>
         <li><a href="#monthlyGraph" data-toggle="tab">Monthly</a></li>
     </ul>
 
     <div class="tab-content">
-        <div class="tab-pane active" id="fiveGraph">
-            <div id="fiveNetworkTrafficGraph" style="height: 300px;"></div>
+        <?php if ($version > 1) { echo "
+        <div class=\"tab-pane active\" id=\"fiveGraph\">
+            <div id=\"fiveNetworkTrafficGraph\" style=\"height: 300px;\"></div>
         </div>
+        "; } ?>
 
-        <div class="tab-pane" id="hourlyGraph">
+        <div class=<?php if ($version == 1) {echo "\"tab-pane active\"";} else {echo "\"tab-pane\"";} ?> id="hourlyGraph">
             <div id="hourlyNetworkTrafficGraph" style="height: 300px;"></div>
         </div>
 
@@ -305,28 +316,30 @@ if (isset($_GET['i'])) {
 <div id="tabNav" class="container">
     <ul class="nav nav-tabs">
         <li class="active">
-            <a href="#five" data-toggle="tab">5Min</a></li>
-        <li><a href="#hourly" data-toggle="tab">Hourly</a></li>
+        <?php if ($version > 1) { echo "<a href=\"#five\" data-toggle=\"tab\">5Min</a></li> <li>"; } ?>
+            <a href="#hourly" data-toggle="tab">Hourly</a></li>
         <li><a href="#daily" data-toggle="tab">Daily</a></li>
         <li><a href="#monthly" data-toggle="tab">Monthly</a></li>
         <li><a href="#top10" data-toggle="tab">Top 10</a></li>
     </ul>
 
     <div class="tab-content">
-        <div class="tab-pane active" id="five">
-            <?php printTableStats($vnstat_bin_dir, "five", $thisInterface, 'Time') ?>
-        </div>
-        <div class="tab-pane" id="hourly">
-            <?php printTableStats($vnstat_bin_dir, "hourly", $thisInterface, 'Hour') ?>
+        <?php if ($version > 1) { echo "
+        <div class=\"tab-pane active\" id=\"five\">";
+            printTableStats($vnstat_cmd, "five", $thisInterface, 'Time');
+        echo "</div>"; } ?>
+
+        <div class=<?php if ($version == 1) {echo "\"tab-pane active\"";} else {echo "\"tab-pane\"";} ?> id="hourly">
+            <?php printTableStats($vnstat_cmd, "hourly", $thisInterface, 'Hour') ?>
         </div>
         <div class="tab-pane" id="daily">
-            <?php printTableStats($vnstat_bin_dir, "daily", $thisInterface, 'Day') ?>
+            <?php printTableStats($vnstat_cmd, "daily", $thisInterface, 'Day') ?>
         </div>
         <div class="tab-pane" id="monthly">
-            <?php printTableStats($vnstat_bin_dir, "monthly", $thisInterface, 'Month') ?>
+            <?php printTableStats($vnstat_cmd, "monthly", $thisInterface, 'Month') ?>
         </div>
         <div class="tab-pane" id="top10">
-            <?php printTableStats($vnstat_bin_dir, "top10", $thisInterface, 'Top 10') ?>
+            <?php printTableStats($vnstat_cmd, "top10", $thisInterface, 'Top 10') ?>
         </div>
     </div>
 </div>

--- a/index.php
+++ b/index.php
@@ -100,8 +100,13 @@ if (isset($vnstat_config)) {
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     <script type="text/javascript">
-        <!-- google.charts.load('45.2', {'packages': ['corechart']}); -->
-        <!-- google.charts.load('45.2', {'packages': ['bar']}); -->
+        $width = getCookie("width");
+        if (!$width || ($width != window.innerWidth)) {
+            //console.log(window.innerWidth);
+            createCookie("width", window.innerWidth, "1");
+            document.location.reload();
+        }
+
         google.charts.load('current', {'packages': ['corechart']});
         google.charts.load('current', {'packages': ['bar']});
         google.charts.setOnLoadCallback(drawFiveChart);
@@ -109,12 +114,33 @@ if (isset($vnstat_config)) {
         google.charts.setOnLoadCallback(drawDailyChart);
         google.charts.setOnLoadCallback(drawMonthlyChart);
 
+        function createCookie(name, value, days) {
+          var expires;
+          if (days) {
+            var date = new Date();
+            date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+            expires = "; expires=" + date.toGMTString();
+          } else {
+           expires = "";
+          }
+          document.cookie = escape(name) + "=" + escape(value) + expires + "; path=/";
+        }
+
+        function getCookie(name) {
+            var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+            return v ? v[2] : null;
+        }
+
         function drawFiveChart()
         {
             let data = google.visualization.arrayToDataTable([
                 [{type: 'datetime', label: 'Time'}, 'Traffic In', 'Traffic Out', 'Total Traffic'],
                 <?php
-                $fiveGraph = getVnstatData($vnstat_cmd, "fiveGraph", $thisInterface);
+                $width = 800;
+                if (isset($_COOKIE["width"])) {
+                    $width = $_COOKIE["width"];
+                }
+                $fiveGraph = getVnstatData($vnstat_cmd, "fiveGraph", $thisInterface, $width);
 
                 $fiveLargestValue = getLargestValue($fiveGraph);
                 $fiveSmallestValue = getSmallestValue($fiveGraph);
@@ -143,6 +169,11 @@ if (isset($vnstat_config)) {
                 title: 'Five minute Network Traffic',
                 subtitle: 'over last 6 hours',
                 orientation: 'horizontal',
+                bar: { groupWidth: '90%' },
+                chartArea: {
+                    left: 60,
+                    width: '85%'
+                },
                 hAxis: { 
                     direction: -1, 
                     format: 'H', 
@@ -193,6 +224,11 @@ if (isset($vnstat_config)) {
                 title: 'Hourly Network Traffic',
                 subtitle: 'over last 24 hours',
                 orientation: 'horizontal',
+                bar: { groupWidth: '90%' },
+                chartArea: {
+                    left: 60,
+                    width: '85%'
+                },
                 hAxis: { 
                     direction: -1, 
                     format: 'd:H',
@@ -289,6 +325,13 @@ if (isset($vnstat_config)) {
     </script>
 </head>
 <body>
+<style>
+   .container{
+     width: 100%;
+     margin: 0 auto;
+   }
+</style>
+
 <div class="container">
     <div class="page-header">
         <h1>Network Traffic (<?php echo $interface_name[$thisInterface]; ?>)</h1> <?php printOptions(); ?>

--- a/index.php
+++ b/index.php
@@ -171,7 +171,7 @@ if (isset($vnstat_config)) {
                 orientation: 'horizontal',
                 bar: { groupWidth: '90%' },
                 chartArea: {
-                    left: 60,
+                    left: 50,
                     width: '85%'
                 },
                 hAxis: { 
@@ -181,7 +181,8 @@ if (isset($vnstat_config)) {
                     title: 'Hour'
                 },
                 vAxis: {
-                    format: '##.## <?php echo $fiveLargestPrefix; ?>',
+                    format: '###.####<?php echo $fiveLargestPrefix; ?>',
+                    textStyle: { fontSize: 12 },
                     scaleType: 'log',
                     baseline: <?php echo pow(10,floor(round(log10($fiveSmallestValue/pow(1024,$fiveMagnitude)),3))); ?>
                 }
@@ -226,7 +227,7 @@ if (isset($vnstat_config)) {
                 orientation: 'horizontal',
                 bar: { groupWidth: '90%' },
                 chartArea: {
-                    left: 60,
+                    left: 50,
                     width: '85%'
                 },
                 hAxis: { 
@@ -235,7 +236,8 @@ if (isset($vnstat_config)) {
                     title: 'Day:Hour'
                 },
                 vAxis: {
-                    format: '##.## <?php echo $hourlyLargestPrefix; ?>',
+                    format: '###.####<?php echo $hourlyLargestPrefix; ?>',
+                    textStyle: { fontSize: 12 },
                     scaleType: 'log',
                     baseline: <?php echo pow(10,floor(round(log10($hourlySmallestValue/pow(1024,$hourlyMagnitude)),3))); ?>
                 }
@@ -248,13 +250,14 @@ if (isset($vnstat_config)) {
         function drawDailyChart()
         {
             let data = google.visualization.arrayToDataTable([
-                ['Day', 'Traffic In', 'Traffic Out', 'Total Traffic'],
+                [{type: 'datetime', label: 'Date'}, 'Traffic In', 'Traffic Out', 'Total Traffic'],
                 <?php
                 $dailyGraph = getVnstatData($vnstat_cmd, "dailyGraph", $thisInterface);
 
                 $dailyLargestValue = getLargestValue($dailyGraph);
                 $dailyLargestPrefix = getLargestPrefix($dailyLargestValue);
                 $dailyMagnitude = getMagnitude($dailyLargestValue);
+                $dailySmallestValue = getSmallestValue($dailyGraph);
 
                 for ($i = 0; $i < count($dailyGraph); $i++) {
                     $day = $dailyGraph[$i]['label'];
@@ -279,11 +282,27 @@ if (isset($vnstat_config)) {
             let options = {
                 title: 'Daily Network Traffic',
                 subtitle: 'over last 30 days (most recent first)',
-                vAxis: {format: '##.## <?php echo $dailyLargestPrefix; ?>'}
+                orientation: 'horizontal',
+                bar: { groupWidth: '90%' },
+                chartArea: {
+                    left: 50,
+                    width: '85%'
+                },
+                hAxis: { 
+                    direction: -1,
+                    format: 'M/d',
+                    title: 'Date: Month/Day'
+                },
+                vAxis: {
+                    format: '###.####<?php echo $dailyLargestPrefix; ?>',
+                    textStyle: { fontSize: 12 },
+                    scaleType: 'log',
+                    baseline: <?php echo pow(10,floor(round(log10($dailySmallestValue/pow(1024,$dailyMagnitude)),3))); ?>
+                }
             };
 
-            let chart = new google.charts.Bar(document.getElementById('dailyNetworkTrafficGraph'));
-            chart.draw(data, google.charts.Bar.convertOptions(options));
+            let chart = new google.visualization.BarChart(document.getElementById('dailyNetworkTrafficGraph'));
+            chart.draw(data, options);
         }
 
         function drawMonthlyChart()
@@ -350,20 +369,20 @@ if (isset($vnstat_config)) {
     <div class="tab-content">
         <?php if ($version > 1) { echo "
         <div class=\"tab-pane active\" id=\"fiveGraph\">
-            <div id=\"fiveNetworkTrafficGraph\" style=\"height: 300px;\"></div>
+            <div id=\"fiveNetworkTrafficGraph\" style=\"height: 400px;\"></div>
         </div>
         "; } ?>
 
         <div class=<?php if ($version == 1) {echo "\"tab-pane active\"";} else {echo "\"tab-pane\"";} ?> id="hourlyGraph">
-            <div id="hourlyNetworkTrafficGraph" style="height: 300px;"></div>
+            <div id="hourlyNetworkTrafficGraph" style="height: 400px;"></div>
         </div>
 
         <div class="tab-pane" id="dailyGraph">
-            <div id="dailyNetworkTrafficGraph" style="height: 300px;"></div>
+            <div id="dailyNetworkTrafficGraph" style="height: 400px;"></div>
         </div>
 
         <div class="tab-pane" id="monthlyGraph">
-            <div id="monthlyNetworkTrafficGraph" style="height: 300px;"></div>
+            <div id="monthlyNetworkTrafficGraph" style="height: 400px;"></div>
         </div>
     </div>
 </div>

--- a/index.php
+++ b/index.php
@@ -191,11 +191,13 @@ if (isset($vnstat_config)) {
                     direction: -1, 
                     format: 'H:mm', 
                     minorGridlines: { count: 0 },
-                    title: 'Hour:Minute',
-                    viewWindow: {
-                        min: new <?php echo $fiveGraph[$lastSample]['label']; ?>,
-                        max: new <?php echo $fiveGraph[0]['label']; ?>
-                    }
+                    title: 'Hour:Minute  Scroll to zoom, Drag to pan'
+                    <?php if (count($fiveGraph) > 0) {
+                        echo ", viewWindow: {";
+                        echo "min: new " . $fiveGraph[$lastSample]['label'] . ", ";
+                        echo "max: new " . $fiveGraph[0]['label'];
+                        echo "}";
+                    } ?>
                 },
                 vAxis: {
                     format: '###.####<?php echo $fiveLargestPrefix; ?>',
@@ -269,7 +271,7 @@ if (isset($vnstat_config)) {
                     direction: -1, 
                     format: 'd:H', 
                     minorGridlines: { count: 0 },
-                    title: 'Day:Hour',
+                    title: 'Day:Hour  Scroll to zoom, Drag to pan',
                     viewWindow: {
                         min: new <?php echo $hourlyGraph[$lastSample]['label']; ?>,
                         max: new <?php echo $hourlyGraph[0]['label']; ?>
@@ -346,7 +348,7 @@ if (isset($vnstat_config)) {
                     direction: -1, 
                     format: 'M/d', 
                     //minorGridlines: { count: 0 },
-                    title: 'Date: Month/Day',
+                    title: 'Month/Day  Scroll to zoom, Drag to pan',
                     viewWindow: {
                         min: new <?php echo $dailyGraph[$lastSample]['label']; ?>,
                         max: new <?php echo $dailyGraph[0]['label']; ?>

--- a/vnstat.php
+++ b/vnstat.php
@@ -43,7 +43,7 @@ function bytesToString($bytes, $wSuf = false, $magnitude = null)
     }
 
     if ($wSuf == true) {
-        return sprintf("%0.4f", ($bytes / pow(1024, $ui)));
+        return sprintf("%0.6f", ($bytes / pow(1024, $ui)));
     } else {
         return sprintf("%0.2f %s", ($bytes / pow(1024, $ui)), $units[$ui]);
     }
@@ -102,7 +102,7 @@ function getSmallestValue($array)
 
 function getLargestPrefix($bytes)
 {
-    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $units = ['B', 'K', 'M', 'G', 'T'];
 
     return $units[getMagnitude($bytes)];
 }
@@ -164,7 +164,7 @@ function getVnstatData($path, $type, $interface, $width = 800)
     if( $version > 1 ){
     $i = 0;
     $j = 0;
-    $duration = floor(($width-200)/7);
+    $duration = floor(($width-200)/9);
     if ($duration < 40) { $duration = 40; }
     $duration = $duration * 180;
     foreach ($vnstatDecoded['interfaces'][0]['traffic']['fiveminute'] as $min) {
@@ -204,7 +204,7 @@ function getVnstatData($path, $type, $interface, $width = 800)
             $daily[$i]['total'] = bytesToString($day['rx'] + $day['tx']);
             $daily[$i]['time'] = mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']);
 
-            $dailyGraph[$i]['label'] = date('jS', mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']));
+            $dailyGraph[$i]['label'] = sprintf("Date(%d, %d, %d, %d, %d)",$day['date']['year'],$day['date']['month']-1,$day['date']['day'],0,0);
             $dailyGraph[$i]['rx'] = $day['rx'];
             $dailyGraph[$i]['tx'] = $day['tx'];
             $dailyGraph[$i]['total'] = ($day['rx'] + $day['tx']);

--- a/vnstat.php
+++ b/vnstat.php
@@ -17,28 +17,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// $wSuf (without suffix MB, GB, etc)
-function kbytesToString($kb, $wSuf = false, $byte_notation = null)
+$logk = log(1024);
+$terraB = pow(1024,4);
+
+function getMagnitude($bytes)
 {
-    $units = ['TB', 'GB', 'MB', 'KB'];
-    $scale = 1024 * 1024 * 1024 * 1024;
-    $ui = 0;
+    global $logk;
 
-    $custom_size = isset($byte_notation) && in_array($byte_notation, $units);
+    $ui = floor(round(log($bytes)/$logk,3));
+    if ($ui < 0) { $ui = 0; }
+    if ($ui > 4) { $ui = 4; }
 
-    while ((($kb < $scale) && ($scale > 1)) || $custom_size) {
+    return $ui;
+}
 
-        if ($custom_size && $units[$ui] == $byte_notation) {
-            break;
-        }
-        $ui++;
-        $scale = $scale / 1024;
+// $wSuf (without suffix MB, GB, etc)
+function bytesToString($bytes, $wSuf = false, $magnitude = null)
+{
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    if (isset($magnitude)) {
+        $ui = $magnitude;
+    } else {
+        $ui = getMagnitude($bytes);
     }
 
     if ($wSuf == true) {
-        return sprintf("%0.2f", ($kb / $scale));
+        return sprintf("%0.2f", ($bytes / pow(1024, $ui)));
     } else {
-        return sprintf("%0.2f %s", ($kb / $scale), $units[$ui]);
+        return sprintf("%0.2f %s", ($bytes / pow(1024, $ui)), $units[$ui]);
     }
 }
 
@@ -69,18 +75,35 @@ function getLargestValue($array)
     });
 }
 
-function getLargestPrefix($kb)
+function getSmallestValue($array)
 {
-    $units = ['TB', 'GB', 'MB', 'KB'];
-    $scale = 1024 * 1024 * 1024;
-    $ui = 0;
+    global $terraB;
 
-    while ((($kb < $scale) && ($scale > 1))) {
-        $ui++;
-        $scale = $scale / 1024;
+    $max = array_reduce($array, function ($a, $b) {
+        if  ((0 < $b['rx']) && ($b['rx'] < $b['tx'])) {
+            $sml = $b['rx'];
+        } else {
+            $sml = $b['tx'];
+        }
+        if (($sml == 0) || ($a < $sml)) {
+            return $a;
+        } else {
+            return $sml;
+        }
+    }, $terraB);
+
+    if ($max < $terraB) {
+        return $max;
     }
 
-    return $units[$ui];
+    return 1;
+}
+
+function getLargestPrefix($bytes)
+{
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+    return $units[getMagnitude($bytes)];
 }
 
 function getVnstatData($path, $type, $interface)
@@ -103,6 +126,8 @@ function getVnstatData($path, $type, $interface)
 
     $vnstatDecoded = json_decode($vnstatDecoded, true);
 
+    $fiveGraph = [];
+    $five = [];
     $hourlyGraph = [];
     $hourly = [];
     $dailyGraph = [];
@@ -110,6 +135,10 @@ function getVnstatData($path, $type, $interface)
     $monthlyGraph = [];
     $monthly = [];
     $top10 = [];
+    $version = 1;
+    if( isset( $vnstatDecoded['jsonversion'] )){
+	    $version = $vnstatDecoded['jsonversion'];
+    }
 
     $i = 0;
     foreach ($vnstatDecoded['interfaces'][0]['traffic']['top'] as $top) {
@@ -117,10 +146,36 @@ function getVnstatData($path, $type, $interface)
             ++$i;
 
             $top10[$i]['label'] = date('d/m/Y', strtotime($top['date']['month'] . "/" . $top['date']['day'] . "/" . $top['date']['year']));
-            $top10[$i]['rx'] = kbytesToString($top['rx']);
-            $top10[$i]['tx'] = kbytesToString($top['tx']);
+            $top10[$i]['rx'] = bytesToString($top['rx']);
+            $top10[$i]['tx'] = bytesToString($top['tx']);
             $top10[$i]['totalraw'] = ($top['rx'] + $top['tx']);
-            $top10[$i]['total'] = kbytesToString($top['rx'] + $top['tx']);
+            $top10[$i]['total'] = bytesToString($top['rx'] + $top['tx']);
+        }
+    }
+
+    $i = 0;
+    $j = 0;
+    foreach ($vnstatDecoded['interfaces'][0]['traffic']['fiveminute'] as $min) {
+        if (is_array($min)) {
+            ++$i;
+
+            $five[$i]['label'] = date('m/d G:i', mktime($min['time']['hour'], $min['time']['minute'], 0, $min['date']['month'], $min['date']['day'], $min['date']['year']));
+            $five[$i]['rx'] = bytesToString($min['rx']);
+            $five[$i]['tx'] = bytesToString($min['tx']);
+            $five[$i]['totalraw'] = ($min['rx'] + $min['tx']);
+            $five[$i]['total'] = bytesToString($min['rx'] + $min['tx']);
+            $five[$i]['time'] = mktime($min['time']['hour'], $min['time']['minute'], 0, $min['date']['month'], $min['date']['day'], $min['date']['year']);
+
+            if (time() - $five[$i]['time'] > 6 * 60 * 60) {
+                continue;
+            }
+            ++$j;
+
+            $fiveGraph[$j]['label'] = sprintf("Date(%d, %d, %d, %d, %d)",$min['date']['year'],$min['date']['month']-1,$min['date']['day'],$min['time']['hour'],$min['time']['minute']);
+            $fiveGraph[$j]['rx'] = $min['rx'];
+            $fiveGraph[$j]['tx'] = $min['tx'];
+            $fiveGraph[$j]['total'] = ($min['rx'] + $min['tx']);
+            $fiveGraph[$j]['time'] = mktime($min['time']['hour'], $min['time']['minute'], 0, $min['date']['month'], $min['date']['day'], $min['date']['year']);
         }
     }
 
@@ -130,10 +185,10 @@ function getVnstatData($path, $type, $interface)
             ++$i;
 
             $daily[$i]['label'] = date('d/m/Y', mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']));
-            $daily[$i]['rx'] = kbytesToString($day['rx']);
-            $daily[$i]['tx'] = kbytesToString($day['tx']);
+            $daily[$i]['rx'] = bytesToString($day['rx']);
+            $daily[$i]['tx'] = bytesToString($day['tx']);
             $daily[$i]['totalraw'] = ($day['rx'] + $day['tx']);
-            $daily[$i]['total'] = kbytesToString($day['rx'] + $day['tx']);
+            $daily[$i]['total'] = bytesToString($day['rx'] + $day['tx']);
             $daily[$i]['time'] = mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']);
 
             $dailyGraph[$i]['label'] = date('jS', mktime(0, 0, 0, $day['date']['month'], $day['date']['day'], $day['date']['year']));
@@ -149,18 +204,24 @@ function getVnstatData($path, $type, $interface)
         if (is_array($hour)) {
             ++$i;
 
-            $hourly[$i]['label'] = date("ga", mktime($hour['id'], 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']));
-            $hourly[$i]['rx'] = kbytesToString($hour['rx']);
-            $hourly[$i]['tx'] = kbytesToString($hour['tx']);
-            $hourly[$i]['totalraw'] = ($hour['rx'] + $hour['tx']);
-            $hourly[$i]['total'] = kbytesToString($hour['rx'] + $hour['tx']);
-            $hourly[$i]['time'] = mktime($hour['id'], 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']);
+            if( $version == 1 ){
+                $h = $hours['id'];
+            } else {
+                $h = $hour['time']['hour'];
+            }
 
-            $hourlyGraph[$i]['label'] = date("ga", mktime($hour['id'], 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']));
+            $hourly[$i]['label'] = date('m/d G:i', mktime($h, 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']));
+            $hourly[$i]['rx'] = bytesToString($hour['rx']);
+            $hourly[$i]['tx'] = bytesToString($hour['tx']);
+            $hourly[$i]['totalraw'] = ($hour['rx'] + $hour['tx']);
+            $hourly[$i]['total'] = bytesToString($hour['rx'] + $hour['tx']);
+            $hourly[$i]['time'] = mktime($h, 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']);
+
+            $hourlyGraph[$i]['label'] = date("ga", mktime($h, 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']));
             $hourlyGraph[$i]['rx'] = $hour['rx'];
             $hourlyGraph[$i]['tx'] = $hour['tx'];
             $hourlyGraph[$i]['total'] = ($hour['rx'] + $hour['tx']);
-            $hourlyGraph[$i]['time'] = mktime($hour['id'], 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']);
+            $hourlyGraph[$i]['time'] = mktime($h, 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']);
         }
     }
 
@@ -172,10 +233,10 @@ function getVnstatData($path, $type, $interface)
             ++$i;
 
             $monthly[$i]['label'] = date('F', mktime(0, 0, 0, $month['date']['month'], 10));
-            $monthly[$i]['rx'] = kbytesToString($month['rx']);
-            $monthly[$i]['tx'] = kbytesToString($month['tx']);
+            $monthly[$i]['rx'] = bytesToString($month['rx']);
+            $monthly[$i]['tx'] = bytesToString($month['tx']);
             $monthly[$i]['totalraw'] = ($month['rx'] + $month['tx']);
-            $monthly[$i]['total'] = kbytesToString($month['rx'] + $month['tx']);
+            $monthly[$i]['total'] = bytesToString($month['rx'] + $month['tx']);
             $monthly[$i]['time'] = mktime(0, 0, 0, $month['date']['month'], 1, $month['date']['year']);
 
             $monthlyGraph[$i]['label'] = date('F', mktime(0, 0, 0, $month['date']['month'], 10));
@@ -194,6 +255,8 @@ function getVnstatData($path, $type, $interface)
         }
     };
 
+    usort($five, $sorting_function);
+    usort($fiveGraph, $sorting_function);
     usort($hourly, $sorting_function);
     usort($hourlyGraph, $sorting_function);
     usort($daily, $sorting_function);
@@ -211,16 +274,20 @@ function getVnstatData($path, $type, $interface)
     });
 
     switch ($type) {
+        case "fiveGraph":
+            return $fiveGraph;
+        case "five":
+            return $five;
         case "hourlyGraph":
-            return $hourlyGraph;
+            return array_slice($hourlyGraph, 0, 24, true);
         case "hourly":
             return $hourly;
         case "dailyGraph":
-            return $dailyGraph;
+            return array_slice($dailyGraph, 0, 30, true);
         case "daily":
             return $daily;
         case "monthlyGraph":
-            return $monthlyGraph;
+            return array_slice($monthlyGraph, 0, 12, true);
         case "monthly":
             return $monthly;
         case "top10":

--- a/vnstat.php
+++ b/vnstat.php
@@ -43,7 +43,7 @@ function bytesToString($bytes, $wSuf = false, $magnitude = null)
     }
 
     if ($wSuf == true) {
-        return sprintf("%0.2f", ($bytes / pow(1024, $ui)));
+        return sprintf("%0.4f", ($bytes / pow(1024, $ui)));
     } else {
         return sprintf("%0.2f %s", ($bytes / pow(1024, $ui)), $units[$ui]);
     }
@@ -107,7 +107,7 @@ function getLargestPrefix($bytes)
     return $units[getMagnitude($bytes)];
 }
 
-function getVnstatData($path, $type, $interface)
+function getVnstatData($path, $type, $interface, $width = 800)
 {
     global $version;
 
@@ -164,6 +164,9 @@ function getVnstatData($path, $type, $interface)
     if( $version > 1 ){
     $i = 0;
     $j = 0;
+    $duration = floor(($width-200)/7);
+    if ($duration < 40) { $duration = 40; }
+    $duration = $duration * 180;
     foreach ($vnstatDecoded['interfaces'][0]['traffic']['fiveminute'] as $min) {
         if (is_array($min)) {
             ++$i;
@@ -175,7 +178,7 @@ function getVnstatData($path, $type, $interface)
             $five[$i]['total'] = bytesToString($min['rx'] + $min['tx']);
             $five[$i]['time'] = mktime($min['time']['hour'], $min['time']['minute'], 0, $min['date']['month'], $min['date']['day'], $min['date']['year']);
 
-            if (time() - $five[$i]['time'] > 6 * 60 * 60) {
+            if (time() - $five[$i]['time'] > $duration) {
                 continue;
             }
             ++$j;

--- a/vnstat.php
+++ b/vnstat.php
@@ -227,7 +227,7 @@ function getVnstatData($path, $type, $interface)
             $hourly[$i]['total'] = bytesToString($hour['rx'] + $hour['tx']);
             $hourly[$i]['time'] = mktime($h, 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']);
 
-            $hourlyGraph[$i]['label'] = date("ga", mktime($h, 0, 0, $hour['date']['month'], $hour['date']['day'], $hour['date']['year']));
+            $hourlyGraph[$i]['label'] = sprintf("Date(%d, %d, %d, %d, %d)",$hour['date']['year'],$hour['date']['month']-1,$hour['date']['day'],$h,0);
             $hourlyGraph[$i]['rx'] = $hour['rx'];
             $hourlyGraph[$i]['tx'] = $hour['tx'];
             $hourlyGraph[$i]['total'] = ($hour['rx'] + $hour['tx']);

--- a/vnstat.php
+++ b/vnstat.php
@@ -19,6 +19,7 @@
 
 $logk = log(1024);
 $terraB = pow(1024,4);
+$version = 1;
 
 function getMagnitude($bytes)
 {
@@ -108,6 +109,8 @@ function getLargestPrefix($bytes)
 
 function getVnstatData($path, $type, $interface)
 {
+    global $version;
+
     $vnstat_information = []; // Create an empty array for use later
 
     $vnstatJSON = popen("$path --json -i $interface", "r");
@@ -135,13 +138,18 @@ function getVnstatData($path, $type, $interface)
     $monthlyGraph = [];
     $monthly = [];
     $top10 = [];
-    $version = 1;
+
     if( isset( $vnstatDecoded['jsonversion'] )){
-	    $version = $vnstatDecoded['jsonversion'];
+        $version = $vnstatDecoded['jsonversion'];
+    }
+
+    $s='';
+    if( $version == 1 ){
+        $s = 's';
     }
 
     $i = 0;
-    foreach ($vnstatDecoded['interfaces'][0]['traffic']['top'] as $top) {
+    foreach ($vnstatDecoded['interfaces'][0]['traffic']['top'.$s] as $top) {
         if (is_array($top)) {
             ++$i;
 
@@ -153,6 +161,7 @@ function getVnstatData($path, $type, $interface)
         }
     }
 
+    if( $version > 1 ){
     $i = 0;
     $j = 0;
     foreach ($vnstatDecoded['interfaces'][0]['traffic']['fiveminute'] as $min) {
@@ -178,9 +187,10 @@ function getVnstatData($path, $type, $interface)
             $fiveGraph[$j]['time'] = mktime($min['time']['hour'], $min['time']['minute'], 0, $min['date']['month'], $min['date']['day'], $min['date']['year']);
         }
     }
+    }
 
     $i = 0;
-    foreach ($vnstatDecoded['interfaces'][0]['traffic']['day'] as $day) {
+    foreach ($vnstatDecoded['interfaces'][0]['traffic']['day'.$s] as $day) {
         if (is_array($day)) {
             ++$i;
 
@@ -200,12 +210,12 @@ function getVnstatData($path, $type, $interface)
     }
 
     $i = 0;
-    foreach ($vnstatDecoded['interfaces'][0]['traffic']['hour'] as $hour) {
+    foreach ($vnstatDecoded['interfaces'][0]['traffic']['hour'.$s] as $hour) {
         if (is_array($hour)) {
             ++$i;
 
             if( $version == 1 ){
-                $h = $hours['id'];
+                $h = $hour['id'];
             } else {
                 $h = $hour['time']['hour'];
             }
@@ -225,10 +235,10 @@ function getVnstatData($path, $type, $interface)
         }
     }
 
-    asort($vnstatDecoded['interfaces'][0]['traffic']['month']);
+    asort($vnstatDecoded['interfaces'][0]['traffic']['month'.$s]);
 
     $i = 0;
-    foreach ($vnstatDecoded['interfaces'][0]['traffic']['month'] as $month) {
+    foreach ($vnstatDecoded['interfaces'][0]['traffic']['month'.$s] as $month) {
         if (is_array($month)) {
             ++$i;
 


### PR DESCRIPTION
Tested with vnstat 2.3 (latest)
This includes the json v2 fix.
Since 5 minute data is noisier I used the logarithmic scale. 
The material design graph does not support log so the legacy graph is used.

I am a first time user of both php and github, so sorry if I made a mess.
I mostly did this for my own use and as a learning tool  - but here it is in case anybody else wants it.
