### PR TITLE
FIX: Provided docker-compose won't find vnstat binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.0-apache
 MAINTAINER Alex Marston <alexander.marston@gmail.com>
 
 # Install Git
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y git unzip vnstat
 
 # Install Composer to handle dependencies
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,5 @@ services:
     container_name: vnstat-dashboard
     volumes:
           - /var/lib/vnstat:/var/lib/vnstat
-          - /usr/bin/vnstat:/usr/local/bin/vnstat
           - /etc/localtime:/etc/localtime:ro
           - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Hey there,

I just installed your application using the provided docker-compose file.
When starting it, it was displaying the following error:

`Fatal error: Uncaught Exception: JSON is invalid in /var/www/html/includes/vnstat.php:60 Stack trace: #0 /var/www/html/includes/vnstat.php(44): vnStat->processVnstatData('') #1 /var/www/html/index.php(27): vnStat->__construct('x/usr/bin/vnsta...') #2 {main} thrown in /var/www/html/includes/vnstat.php on line 60`

After some searching I found that your [default config](https://github.com/alexandermarston/vnstat-dashboard/blob/master/app/includes/config.php#L28) has this option set:
`$vnstat_bin_dir = '/usr/bin/vnstat';`

But the docker-compose points to /usr/local/bin/vnstat.

So there are two possible fixes in my opinion:
a) Update the config to /usr/local/bin/vnstat
b) add apt-get install vnstat to the Dockerfile

I'd go for option b, because option a would break the default config for non-docker users and I am not sure what would happen, if the docker host uses different lib versions than the container.
If you install vnstat via apt-get in the container, I would think, this is the best way.

So here is a pull request for option b.

Br
DerBunman