### PR TITLE
sort interfaces

### DIFF
--- a/app/includes/vnstat.php
+++ b/app/includes/vnstat.php
@@ -80,7 +80,7 @@ class vnStat {
 		foreach($this->vnstatData['interfaces'] as $interface) {
 			array_push($vnstatInterfaces, $interface['id']);
 		}
-
+        asort($vnstatInterfaces);
 		return $vnstatInterfaces;
 	}
 


### PR DESCRIPTION
On some versions of the OS (for example, Debian), the array is sorted in the reverse order