### PR TITLE
Fix number formatting for javascript

### DIFF
--- a/app/includes/utilities.php
+++ b/app/includes/utilities.php
@@ -52,7 +52,7 @@ function formatBytesTo($bytes, $delimiter, $decimals = 2) {
 
     $i = array_search($delimiter, $sizes);
 
-    return number_format(($bytes / pow($k, $i)), $decimals);
+    return number_format(($bytes / pow($k, $i)), $decimals, '.', '');
 }
 
 function kibibytesToBytes($kibibytes, $vnstatJsonVersion) {


### PR DESCRIPTION
If the traffic is over 1000 GB a day it would write that out as "1,000.00" which
isn't valid javascript and would break the frontend graph. Make sure to not
use a thousands separator to fix this.